### PR TITLE
fix: persist empty temp_dir folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/terraform/
 **/tf_backup
 td2bq_mapper/tests/temp_dir/*.*
+!td2bq_mapper/tests/temp_dir/.gitkeep
 terraform_generated/*.*
 json_generated/*.*
 logs/


### PR DESCRIPTION
Modified .gitignore to keep .gitkeep in tests/temp_dir so that the empty directory is kept, but not other files in it.