### PR TITLE
Fix unmapped report

### DIFF
--- a/td2bq.py
+++ b/td2bq.py
@@ -286,7 +286,7 @@ def validate_acl(td_acl_file, parent_change_folder) -> dict:
 def create_change_files(td_acl_file: str, change_folder: str, overwrite: bool):
     """Validate TD permissions and output change files.
 
-    Validate if all TD permissions can be transalted to BQ IAM.
+    Validate if all TD permissions can be translated to BQ IAM.
     It outputs change files, i.e files with TD entities and corresponding
     GCP entities. The user should modify change files to let the ACL mapper know
     what TD entities to map to GCP when generating JSON or Terraform.
@@ -296,16 +296,16 @@ def create_change_files(td_acl_file: str, change_folder: str, overwrite: bool):
       change_folder(str): directory to create change files
       overwrite(bool): If True the Mapper will overwrite the output dirs and files
     """
-    # check if we can overwrite the already esicting files
+    # check if we can overwrite the existing files
     if not td2bq_util.make_dirs(
         change_folder,
         overwrite,
         {
-            td2bq_perm.CHANGE_FILE_GROUP,
-            td2bq_perm.CHANGE_FILE_OBJECT,
-            td2bq_perm.CHANGE_FILE_DATASET,
-            td2bq_perm.CHANGE_FILE_USER,
-            INVALID_ACLS_FILE,
+            os.path.join(change_folder, td2bq_perm.CHANGE_FILE_GROUP),
+            os.path.join(change_folder, td2bq_perm.CHANGE_FILE_OBJECT),
+            os.path.join(change_folder, td2bq_perm.CHANGE_FILE_DATASET),
+            os.path.join(change_folder, td2bq_perm.CHANGE_FILE_USER),
+            os.path.join(change_folder, INVALID_ACLS_FILE),
         },
     ):
         raise ValueError(f"Could not create the output directory {change_folder}")

--- a/td2bq_mapper/td2bq_util.py
+++ b/td2bq_mapper/td2bq_util.py
@@ -137,7 +137,7 @@ def make_dirs(path: str, overwrite: bool, files=None) -> bool:
         )
         if old_files:
             logger.error(
-                "Directory %s contains outputs from the previouse "
+                "Directory %s contains outputs from the previous "
                 "ACL Mapper run. Remove files %s and rerun the mapper.",
                 abs_path,
                 old_files,

--- a/td2bq_mapper/tests/test_td2bq.py
+++ b/td2bq_mapper/tests/test_td2bq.py
@@ -221,8 +221,8 @@ def test_generate_jsons_test8():
     Returns:
       None
     """
-    generate_jsons("test8")
+    generate_jsons("test6")
 
 
 if __name__ == "__main__":
-    test_generate_jsons_test8()
+    test_generate_jsons_test7()

--- a/td2bq_mapper/tests/test_td2bq.py
+++ b/td2bq_mapper/tests/test_td2bq.py
@@ -221,8 +221,8 @@ def test_generate_jsons_test8():
     Returns:
       None
     """
-    generate_jsons("test6")
+    generate_jsons("test8")
 
 
 if __name__ == "__main__":
-    test_generate_jsons_test7()
+    test_generate_jsons_test8()


### PR DESCRIPTION
If the unmapped permissions report present and --overwrite is not set, then don't generate permissions. We are not allowing overwriting the results that are let from the previous mapper run.