### PR TITLE
feat: Remove legacy roles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 # core dependencies
-pandas==1.2.3
-requests==2.26.0
-teradatasql==17.10.0.5
+pandas==1.4.1
+requests==2.27.1
+teradatasql==17.10.0.6
 validate-email==1.3
 
 # formatting dependencies
 autoflake==1.4
-black==21.11b1
+black==22.1.0
 flake8==4.0.1
 isort==5.10.1
 
@@ -17,7 +17,7 @@ click==8.0.3
 idna==3.3
 mccabe==0.6.1
 mypy-extensions==0.4.3
-numpy==1.22.1
+numpy==1.22.2
 pathspec==0.9.0
 platformdirs==2.4.1
 pycodestyle==2.8.0

--- a/td2bq.py
+++ b/td2bq.py
@@ -244,7 +244,7 @@ def validate_acl(td_acl_file, parent_change_folder) -> dict:
             f"in temp directory ({file})"
         )
 
-    logger.info("Temporary change files were mapped to BibQuery.")
+    logger.info("Temporary change files were mapped to BigQuery.")
     # Persist reported n/a errors in a separate file and
     # use them to generate change files:
     old_file = os.path.join(change_folder, td2bq_mod3_map.INVALID_ACLS_FILE)

--- a/td2bq_mapper/td2bq_create_json.py
+++ b/td2bq_mapper/td2bq_create_json.py
@@ -172,13 +172,7 @@ class Td2BqJson:
           bool: True on success. False on failure
         """
         files_created = []  # track what files were created during this run
-        new_dataset_binding = {
-            "access": [  # template for dataset binding
-                {"role": "WRITER", "specialGroup": "projectWriters"},
-                {"role": "OWNER", "specialGroup": "projectOwners"},
-                {"role": "READER", "specialGroup": "projectReaders"},
-            ]
-        }
+        new_dataset_binding = {"access": []}  # template for dataset binding
         result = True
         for iam, dupe_roles in dedupe_mapping.items():
             for role in dupe_roles:

--- a/td2bq_mapper/tests/test6/output/json_generated/datasets/db2.json
+++ b/td2bq_mapper/tests/test6/output/json_generated/datasets/db2.json
@@ -1,18 +1,6 @@
 {
     "access": [
         {
-            "role": "WRITER",
-            "specialGroup": "projectWriters"
-        },
-        {
-            "role": "OWNER",
-            "specialGroup": "projectOwners"
-        },
-        {
-            "role": "READER",
-            "specialGroup": "projectReaders"
-        },
-        {
             "groupByEmail": "data_reader@epishova.joonix.net",
             "role": "projects/acl-mapper-test/roles/td2bq_mapper_bqcustom1"
         }

--- a/td2bq_mapper/tests/test6/output/json_generated/datasets/db3_renamed.json
+++ b/td2bq_mapper/tests/test6/output/json_generated/datasets/db3_renamed.json
@@ -1,18 +1,6 @@
 {
     "access": [
         {
-            "role": "WRITER",
-            "specialGroup": "projectWriters"
-        },
-        {
-            "role": "OWNER",
-            "specialGroup": "projectOwners"
-        },
-        {
-            "role": "READER",
-            "specialGroup": "projectReaders"
-        },
-        {
             "groupByEmail": "data_reader@epishova.joonix.net",
             "role": "projects/acl-mapper-test/roles/td2bq_mapper_bqcustom1"
         }

--- a/td2bq_mapper/tests/test8/output/json_generated/datasets/db1.json
+++ b/td2bq_mapper/tests/test8/output/json_generated/datasets/db1.json
@@ -1,18 +1,6 @@
 {
     "access": [
         {
-            "role": "WRITER",
-            "specialGroup": "projectWriters"
-        },
-        {
-            "role": "OWNER",
-            "specialGroup": "projectOwners"
-        },
-        {
-            "role": "READER",
-            "specialGroup": "projectReaders"
-        },
-        {
             "groupByEmail": "data_reader_2@epishova.joonix.net",
             "role": "projects/acl-mapper-test/roles/td2bq_mapper_bqcustom1"
         }

--- a/td2bq_mapper/tests/test8/output/json_generated/datasets/db2.json
+++ b/td2bq_mapper/tests/test8/output/json_generated/datasets/db2.json
@@ -1,18 +1,6 @@
 {
     "access": [
         {
-            "role": "WRITER",
-            "specialGroup": "projectWriters"
-        },
-        {
-            "role": "OWNER",
-            "specialGroup": "projectOwners"
-        },
-        {
-            "role": "READER",
-            "specialGroup": "projectReaders"
-        },
-        {
             "groupByEmail": "data_reader@epishova.joonix.net",
             "role": "projects/acl-mapper-test/roles/td2bq_mapper_bqcustom1"
         },


### PR DESCRIPTION
Resolves #6. 

Removes the legacy `projectWriters`, `projectReaders`, and `projectOwners` roles.

Also updates pinned requirements and minor typo fix.